### PR TITLE
クイズ終了のタイマーをサーバ側の処理に変更と途中入室でクイズに参加できるように変更

### DIFF
--- a/chatapp/public/javascripts/enter.js
+++ b/chatapp/public/javascripts/enter.js
@@ -16,7 +16,12 @@ socket.on('enterRoom', function (data) {
 socket.on('recieveRestoreEvent', function (rooms) {
     console.log(rooms);
     for (var i = 0; i < rooms.length; i++) {
-      if ($('#userName').val() === rooms[i].name) {
+      if (rooms[i].message_type == 'クイズ'){
+        var obj = JSON.parse(rooms[i].message);
+        $('#thread').prepend('<h3>' + rooms[i].name + 'さんがクイズの森を開始しました。' + '</h3>');
+        $('#thread').prepend('<h3>' + obj.quiz['question'] + '</h3>');
+      }
+      else if ($('#userName').val() === rooms[i].name) {
           $('#thread').prepend(`<div class="message-box my-message"><div class="userName">${rooms[i].name}さん:</div><div class="message">${rooms[i].message}</div>`);
       } else {
           $('#thread').prepend(`<div class="message-box"><div class="userName">${rooms[i].name}さん:</div><div class="message">${rooms[i].message}</div>`);

--- a/chatapp/public/javascripts/publish.js
+++ b/chatapp/public/javascripts/publish.js
@@ -25,6 +25,9 @@ function publish() {
         alert('正解しました！');
         exit();
     }
+    else{
+      console.log(answer+ '不正解');
+    }
 
     // 投稿内容を送信
     socket.emit('sendMessage', userMessage);

--- a/chatapp/public/javascripts/quiz.js
+++ b/chatapp/public/javascripts/quiz.js
@@ -12,6 +12,16 @@ function quiz() {
 
 // サーバから受信した退室メッセージを画面上に表示する
 socket.on('receiveQuizMessageEvent', function (data) {
+  setInterval(count_down, 1000);
+  function count_down() {
+    count--;
+    const count_text = 'クイズ回答終了まで'
+    $('#countdown').text(count);
+    // 0秒になった時
+    if(count == 0) {
+      location.href = '/end';
+  }
+}
     // ここにクイズボタンを消す処理
     $('.room-quiz_button').hide();
     //　ここに投稿ボタンを回答ボタンに変える処理

--- a/chatapp/public/javascripts/time.js
+++ b/chatapp/public/javascripts/time.js
@@ -11,27 +11,24 @@
       count--;
       const count_text = 'クイズ回答終了まで'
       $('#countdown').text(count);
-      //　ここに復元機能を呼び出す
-      // socket.emit('sendQuizModeEvent');
       // 0秒になった時
       if(count == 0) {
-      location.href = '/end';
+        location.href = '/end';
     }
   }
   }
 
   // クイズボタンがクリックされた場合の処理
   $('.room-quiz_button').click(function(){
+    socket.emit('sendQuizModeEvent',count);
     setInterval(count_down, 1000);
     function count_down() {
       count--;
       const count_text = 'クイズ回答終了まで'
       $('#countdown').text(count);
-      //　ここに復元機能を呼び出す
-      // socket.emit('sendQuizModeEvent');
       // 0秒になった時
       if(count == 0) {
-      location.href = '/end';
+        location.href = '/end';
     }
   }
   });

--- a/chatapp/public/javascripts/time.js
+++ b/chatapp/public/javascripts/time.js
@@ -6,6 +6,7 @@
     // 表示の場合
   } else {
     // 非表示の場合
+    socket.emit('sendQuizModeEvent',count);
     setInterval(count_down, 1000);
     function count_down() {
       count--;

--- a/chatapp/public/javascripts/time.js
+++ b/chatapp/public/javascripts/time.js
@@ -22,14 +22,4 @@
   // クイズボタンがクリックされた場合の処理
   $('.room-quiz_button').click(function(){
     socket.emit('sendQuizModeEvent',count);
-    setInterval(count_down, 1000);
-    function count_down() {
-      count--;
-      const count_text = 'クイズ回答終了まで'
-      $('#countdown').text(count);
-      // 0秒になった時
-      if(count == 0) {
-        location.href = '/end';
-    }
-  }
   });

--- a/chatapp/routes/index.js
+++ b/chatapp/routes/index.js
@@ -4,6 +4,7 @@ const express = require('express');
 const router = express.Router();
 const db = require('../db/db').db;
 let quiz_start = "button";
+let quiz_button = "投稿";
 /**
  * Chat Entity
  */
@@ -49,13 +50,15 @@ router.post('/room', async function(request, response, next) {
   const chat = new chatModel();
   let quiz_status = '';
   quiz_status = await chat.findById(1);
-  console.log('ユーザ名：' + request.body.userName);
+  console.log('ユーザ名：' + request.body.userName+quiz_status.quiz_start);
     if (quiz_status.quiz_start==0){
       quiz_start = "button";
+      quiz_button = '投稿';
     }else{
       quiz_start = "hidden";
+      quiz_button = '回答';
     }
-    response.render('room', { userName: request.body.userName, quizrStart:  quiz_start});
+    response.render('room', { userName: request.body.userName, quizrStart:  quiz_start, quizButton :quiz_button});
 });
 
 // リダイレクト先の表示

--- a/chatapp/sockets/index.js
+++ b/chatapp/sockets/index.js
@@ -20,5 +20,8 @@ module.exports = function (server) {
 
         // 復元モジュールの呼出
         require('./restore')(socket, io);
+
+        // クイズ’終了モジュールの呼出
+        require('./quitQuizMode')(socket);
     });
 };

--- a/chatapp/sockets/quitQuizMode.js
+++ b/chatapp/sockets/quitQuizMode.js
@@ -1,13 +1,17 @@
 'use strict';
 const db = require('../db/db').db;
-
 module.exports = function (socket, io) {
   // 退室メッセージをクライアントに送信する
-  socket.on('sendQuizModeEvent', function (data) {
-    if (!data) {
-      return;
-    }
+  socket.on('sendQuizModeEvent', function (count) {
+    console.log(count);
     // DBのクイズ状態の更新
-    db.run('UPDATE chat SET quiz_start = ? WHERE id = ?', [0, 1]);
+    setInterval(count_down, 1000);
+    function count_down() {
+      count--;
+      if(count == 0) {
+        db.run('UPDATE chat SET quiz_start = ? WHERE id = ?', [0, 1]);
+    }
+  }
+    // db.run('UPDATE chat SET quiz_start = ? WHERE id = ?', [0, 1]);
   });
 };

--- a/chatapp/sockets/quiz.js
+++ b/chatapp/sockets/quiz.js
@@ -27,7 +27,7 @@ module.exports = function (socket, io) {
       quiz
     };
     // DBのクイズ状態の更新
-    db.run('UPDATE chat SET quiz_start = ? WHERE id = ?', [0, 1]);
+    db.run('UPDATE chat SET quiz_start = ? WHERE id = ?', [1, 1]);
     // 全クライアントが受信するメッセージ表示イベント（receiveQuizMessageEvent）を送信する
     io.sockets.emit('receiveQuizMessageEvent', data);
     io.sockets.emit('receiveQuizAnswer', data.quiz['answer']);

--- a/chatapp/sockets/quiz.js
+++ b/chatapp/sockets/quiz.js
@@ -1,5 +1,28 @@
 'use strict';
 const db = require('../db/db').db;
+var roomModel = require('../db/room-model');
+/**
+ * Room Entity
+ */
+class RoomEntity {
+  /**
+   * コンストラクタ
+   *
+   * @param id ID
+   * @param name room名
+   * @param message 投稿内容
+   * @param date 投稿した日付
+   * @param message_type 投稿の種類（チャット、メモ、回答）
+   */
+  constructor(id, name, room_id, message, date, message_type) {
+    this.id   = id;
+    this.name = name;
+    this.room_id = room_id;
+    this.message  = message;
+    this.date = date;
+    this.message_type = message_type
+  }
+}
 const quiz_db = [
   {
     "question": "りんごのいろは？",
@@ -17,19 +40,29 @@ const quiz_db = [
 
 module.exports = function (socket, io) {
   // 退室メッセージをクライアントに送信する
-  socket.on('sendQuizMessageEvent', function (data) {
+  socket.on('sendQuizMessageEvent', async function (data) {
     if (!data) {
       return;
     }
     let quiz = quiz_db[Math.floor(Math.random() * quiz_db.length)];
-    data = {
+    let quiz_data = {}
+    quiz_data = {
       data,
       quiz
     };
+    console.log(quiz_data);
+
     // DBのクイズ状態の更新
     db.run('UPDATE chat SET quiz_start = ? WHERE id = ?', [1, 1]);
     // 全クライアントが受信するメッセージ表示イベント（receiveQuizMessageEvent）を送信する
-    io.sockets.emit('receiveQuizMessageEvent', data);
-    io.sockets.emit('receiveQuizAnswer', data.quiz['answer']);
+    io.sockets.emit('receiveQuizMessageEvent', quiz_data);
+    io.sockets.emit('receiveQuizAnswer', quiz_data.quiz['answer']);
+    //　投稿内容をDBに保存
+    var today = new Date();
+    const room = new roomModel();
+    var result = today.getFullYear() + "-" + (today.getMonth()+1) + "-" + today.getDate() + " " + today.getHours() + ":" + today.getMinutes() +":"+ today.getSeconds();
+    var json = JSON.stringify(quiz_data);
+
+    await room.create(new RoomEntity(null,quiz_data.data,1,json,result,'クイズ'));
   });
 };

--- a/chatapp/sockets/restore.js
+++ b/chatapp/sockets/restore.js
@@ -11,6 +11,16 @@ module.exports = function (socket, io) {
     }
     const room = new roomModel();
     const rooms = await room.findAll();
+    for ( var i = rooms.length-1;  i > 0;  i--  ) {
+      console.log(rooms[i].message_type);
+      // console.log(rooms[i].message_type);
+      if (rooms[i].message_type == 'クイズ'){
+        var obj = JSON.parse(rooms[i].message);
+        console.log('test',obj.quiz['answer']);
+        io.to(socket.id).emit('receiveQuizAnswer', obj.quiz['answer']);
+        break;
+      }
+    }
     io.to(socket.id).emit('recieveRestoreEvent', rooms) //特定のユーザーのみ（socket.idで送信元のみに送信）
   });
 };

--- a/chatapp/views/room.hbs
+++ b/chatapp/views/room.hbs
@@ -12,7 +12,7 @@
                 <textarea id="message" rows="4" class="room-message_textarea" placeholder="投稿文を入力してください"></textarea>
             </div>
             <div id="room-submit"class="room-submit">
-                <input id="btn-text" type="button" value="投稿" class="common-button room-publish_button" onclick="publish();">
+                <input id="btn-text" type="button" value="{{quizButton}}" class="common-button room-publish_button" onclick="publish();">
                 <input type="button" value="メモ" class="common-button room-memo_button" onclick="memo();">
                 <input type="{{quizrStart}}" value="クイズ" class="common-button room-quiz_button" onclick="quiz();">
                 <input type="button" id="take_break_button" value="休止する" class="common-button room-takebreak-button"


### PR DESCRIPTION
クイズの終了タイマーがクライアント側で制御されていたので、サーバ側の処理に統一しました。
クイズボタンが押された際にサーバに通知しカウントダウンを開始します。

クイズを開始されて途中入室した際に、クイズに参加できない問題を解消